### PR TITLE
If Podfile.lock found use that, not Gemfile.lock

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -18,6 +18,7 @@ workflows:
     envs:
     # define this!
     - REPO_URL: $REPO_URL
+    - TEST_REPO_BRANCH: $TEST_REPO_BRANCH
     - PODFILE_PTH: $PODFILE_PTH
     steps:
     - script:
@@ -27,7 +28,7 @@ workflows:
             set -ex
             rm -rf ./_tmp
 
-            git clone "${REPO_URL}" ./_tmp
+            git clone "${REPO_URL}" ./_tmp --branch "${TEST_REPO_BRANCH}"
     - script:
         title: Switch working dir to test/_tmp dir
         description: |-
@@ -38,13 +39,21 @@ workflows:
         - content: envman add --key BITRISE_SOURCE_DIR --value "$(pwd)/_tmp"
     - path::./:
         inputs:
-        - is_update_cocoapods: "false"
         - podfile_path: $PODFILE_PTH
 
   test_with_gemfile:
     envs:
     # With Gemfile:
     - REPO_URL: https://github.com/bitrise-samples/ios-cocoapods-1.x-Gemfile.git
+    - TEST_REPO_BRANCH: master
+    - PODFILE_PTH: ''
+    after_run:
+    - _test_with_repo
+  test_with_no_podfile_lock:
+    envs:
+    # With Only Gemfile (no Podfile.lock):
+    - REPO_URL: https://github.com/bitrise-samples/ios-cocoapods-1.x-Gemfile.git
+    - TEST_REPO_BRANCH: no-podfile-lock
     - PODFILE_PTH: ''
     after_run:
     - _test_with_repo
@@ -52,6 +61,7 @@ workflows:
     envs:
     # Without Gemfile:
     - REPO_URL: https://github.com/bitrise-samples/ios-cocoapods-1.x.git
+    - TEST_REPO_BRANCH: master
     - PODFILE_PTH: ''
     after_run:
     - _test_with_repo
@@ -59,6 +69,7 @@ workflows:
     envs:
     # Without Gemfile:
     - REPO_URL: https://github.com/bitrise-samples/ios-cocoapods-1.x.git
+    - TEST_REPO_BRANCH: master
     - PODFILE_PTH: 'CocoaPods1X/Podfile'
     after_run:
     - _test_with_repo
@@ -66,6 +77,7 @@ workflows:
     envs:
     # Podfile is in repo root
     - REPO_URL: https://github.com/bitrise-samples/ios-cocoapods-at-root.git
+    - TEST_REPO_BRANCH: master
     - PODFILE_PTH: ''
     after_run:
     - _test_with_repo
@@ -80,6 +92,7 @@ workflows:
     before_run:
     - go-tests
     after_run:
+    - test_with_no_podfile_lock
     - test_with_gemfile
     - test_without_gemfile
     - test_podfile_at_root

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,6 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 app:
   envs:
   - STEP_VERSION: 1.5.9
+  - ORIG_BITRISE_SOURCE_DIR: $BITRISE_SOURCE_DIR
 
 workflows:
   # ----------------------------------------------------------------
@@ -21,6 +22,10 @@ workflows:
     - TEST_REPO_BRANCH: $TEST_REPO_BRANCH
     - PODFILE_PTH: $PODFILE_PTH
     steps:
+    - change-workdir:
+        inputs:
+        - path: "${ORIG_BITRISE_SOURCE_DIR}"
+        - is_create_path: "false"
     - script:
         inputs:
         - content: |-
@@ -29,14 +34,15 @@ workflows:
             rm -rf ./_tmp
 
             git clone "${REPO_URL}" ./_tmp --branch "${TEST_REPO_BRANCH}"
-    - script:
+    - change-workdir:
         title: Switch working dir to test/_tmp dir
         description: |-
           To prevent step testing issues, like referencing relative
           files with just './some-file', which would work for local tests
           but not if the step is included in another bitrise.yml!
         inputs:
-        - content: envman add --key BITRISE_SOURCE_DIR --value "$(pwd)/_tmp"
+        - path: "${ORIG_BITRISE_SOURCE_DIR}/_tmp"
+        - is_create_path: "false"
     - path::./:
         inputs:
         - podfile_path: $PODFILE_PTH

--- a/main.go
+++ b/main.go
@@ -231,7 +231,7 @@ func main() {
 
 		version, err := cocoapodsVersionFromPodfileLock(podfileLockPth)
 		if err != nil {
-			log.Fail("Failed to determin CocoaPods version, error: %s", err)
+			log.Fail("Failed to determine CocoaPods version, error: %s", err)
 		}
 
 		if version != "" {

--- a/main.go
+++ b/main.go
@@ -169,12 +169,12 @@ func main() {
 	// Inputs
 	if os.Getenv("is_update_cocoapods") != "false" {
 		log.Warn("`is_update_cocoapods` is deprecated!")
-		log.Warn("CocoaPods version is determined based on the Gemfile.lock or the Podfile.lock in the Podfile's directory.")
+		log.Warn("CocoaPods version is determined based on the Podfile.lock or the Gemfile.lock in the Podfile's directory.")
 	}
 
 	if os.Getenv("install_cocoapods_version") != "" {
 		log.Warn("`install_cocoapods_version` is deprecated!")
-		log.Warn("CocoaPods version is determined based on the Gemfile.lock or the Podfile.lock in the Podfile's directory.")
+		log.Warn("CocoaPods version is determined based on the Podfile.lock or the Gemfile.lock in the Podfile's directory.")
 	}
 
 	sourceRootPath := os.Getenv("source_root_path")
@@ -219,56 +219,57 @@ func main() {
 	useCocoapodsFromGemfile := false
 	useCocoapodsVersion := ""
 
-	gemfileLockPth := filepath.Join(podfileDir, "Gemfile.lock")
-	log.Details("Searching for Gemfile.lock with cocoapods gem")
-
-	if exist, err := pathutil.IsPathExists(gemfileLockPth); err != nil {
-		log.Fail("Failed to check Gemfile.lock at: %s, error: %s", gemfileLockPth, err)
+	fmt.Println("")
+	log.Details("Searching for Podfile.lock")
+	// Check Podfile.lock for CocoaPods version
+	podfileLockPth := filepath.Join(podfileDir, "Podfile.lock")
+	if exist, err := pathutil.IsPathExists(podfileLockPth); err != nil {
+		log.Fail("Failed to check Podfile.lock at: %s, error: %s", podfileLockPth, err)
 	} else if exist {
-		version, err := cocoapodsVersionFromGemfileLock(gemfileLockPth)
+		// Podfile.lock exist scearch for version
+		log.Details("Found Podfile.lock: %s", podfileLockPth)
+
+		version, err := cocoapodsVersionFromPodfileLock(podfileLockPth)
 		if err != nil {
-			log.Fail("Failed to check if Gemfile.lock contains cocopods, error: %s", err)
+			log.Fail("Failed to determin CocoaPods version, error: %s", err)
 		}
 
 		if version != "" {
-			log.Details("Found Gemfile.lock: %s", gemfileLockPth)
-			log.Done("Gemfile.lock defined cocoapods version: %s", version)
-
-			bundleInstallCmd := []string{"bundle", "install", "--jobs", "20", "--retry", "5"}
-			if err := rubyCommand.Execute(podfileDir, false, bundleInstallCmd); err != nil {
-				log.Fail("Command failed, error: %s", err)
-			}
-
-			useCocoapodsFromGemfile = true
+			useCocoapodsVersion = version
+			log.Done("Required CocoaPods version (from Podfile.lock): %s", useCocoapodsVersion)
+		} else {
+			log.Warn("No CocoaPods version found in Podfile.lock! (%s)", podfileLockPth)
 		}
 	} else {
-		log.Details("No Gemfile.lock with cocoapods gem found at: %s", gemfileLockPth)
+		log.Warn("No Podfile.lock found at: %s", podfileLockPth)
+		log.Warn("Make sure it's committed into your repository!")
 	}
 
-	if !useCocoapodsFromGemfile {
-		fmt.Println("")
-		log.Details("Searching for Podfile.lock")
-		// Check Podfile.lock for CocoaPods version
-		podfileLockPth := filepath.Join(podfileDir, "Podfile.lock")
-		if exist, err := pathutil.IsPathExists(podfileLockPth); err != nil {
-			log.Fail("Failed to check Podfile.lock at: %s, error: %s", podfileLockPth, err)
-		} else if exist {
-			// Podfile.lock exist scearch for version
-			log.Details("Found Podfile.lock: %s", podfileLockPth)
+	if useCocoapodsVersion == "" {
+		gemfileLockPth := filepath.Join(podfileDir, "Gemfile.lock")
+		log.Details("Searching for Gemfile.lock with cocoapods gem")
 
-			version, err := cocoapodsVersionFromPodfileLock(podfileLockPth)
+		if exist, err := pathutil.IsPathExists(gemfileLockPth); err != nil {
+			log.Fail("Failed to check Gemfile.lock at: %s, error: %s", gemfileLockPth, err)
+		} else if exist {
+			version, err := cocoapodsVersionFromGemfileLock(gemfileLockPth)
 			if err != nil {
-				log.Fail("Failed to determin CocoaPods version, error: %s", err)
+				log.Fail("Failed to check if Gemfile.lock contains cocopods, error: %s", err)
 			}
 
-			log.Done("CocoaPods version: %s", version)
-			if version != systemCocoapodsVersion {
-				useCocoapodsVersion = version
+			if version != "" {
+				log.Details("Found Gemfile.lock: %s", gemfileLockPth)
+				log.Done("Gemfile.lock defined cocoapods version: %s", version)
+
+				bundleInstallCmd := []string{"bundle", "install", "--jobs", "20", "--retry", "5"}
+				if err := rubyCommand.Execute(podfileDir, false, bundleInstallCmd); err != nil {
+					log.Fail("Command failed, error: %s", err)
+				}
+
+				useCocoapodsFromGemfile = true
 			}
 		} else {
-			// Use system installed cocoapods
-			log.Warn("No Podfile.lock found at: %s", podfileLockPth)
-			log.Warn("Make sure it's committed into your repository!")
+			log.Details("No Gemfile.lock with cocoapods gem found at: %s", gemfileLockPth)
 			log.Done("Using system installed CocoaPods version")
 		}
 	}

--- a/step.yml
+++ b/step.yml
@@ -5,8 +5,10 @@ summary: |-
 description: |-
   Run CocoaPods install (`$ pod install`) in your App's directory.
 
-  CocoaPods version is determined based on the Gemfile.lock or (if not exists or does not contain cocoapods gem)  
-  on the Podfile.lock in the Podfile's directory.
+  CocoaPods version is determined based on the Podfile.lock or
+  on the Gemfile.lock (if Podfile.lock does not exist in the Podfile's
+  directory and Gemfile.lock contains cocoapods gem)
+  in the Podfile's directory.
 website: https://github.com/bitrise-io/steps-cocoapods-install
 source_code_url: https://github.com/bitrise-io/steps-cocoapods-install
 support_url: https://github.com/bitrise-io/steps-cocoapods-install/issues
@@ -51,7 +53,7 @@ inputs:
       description: |
         __Deprecated!__
 
-        CocoaPods version is determined based on the Gemfile.lock or the Podfile.lock in the Podfile's directory.
+        CocoaPods version is determined based on the Podfile.lock or the Gemfile.lock in the Podfile's directory.
       value_options: ["true", "false"]
       is_expand: false
       is_required: true
@@ -61,7 +63,7 @@ inputs:
       description: |
         __Deprecated!__
 
-        CocoaPods version is determined based on the Gemfile.lock or the Podfile.lock in the Podfile's directory.
+        CocoaPods version is determined based on the Podfile.lock or the Gemfile.lock in the Podfile's directory.
   - verbose: "true"
     opts:
       title: "Execute cocoapods in verbose mode?"


### PR DESCRIPTION
Switched the priority; previously if both `Gemfile.lock` and `Podfile.lock` were in the repo `Gemfile.lock` won. Now `Podfile.lock` wins, and `Gemfile.lock` is only a fallback